### PR TITLE
Fix: premature check for dependencies

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -1,7 +1,7 @@
 module.exports = api => {
   const isTs = api.entryFile.endsWith('.ts')
-  const usesRouter = Boolean(require(api.resolve('package.json')).dependencies['vue-router'])
-  const projectName = require(api.resolve('package.json')).name;
+  const packageJson = require(api.resolve('package.json'));
+  const usesRouter = Boolean(packageJson.dependencies && packageJson.dependencies['vue-router']);
 
   api.render({
     [api.entryFile]: './template/src/main.js',
@@ -9,7 +9,7 @@ module.exports = api => {
   }, {
     isTs,
     usesRouter,
-    appName: projectName,
+    appName: packageJson.name,
   });
 
   api.extendPackage({

--- a/generator.js
+++ b/generator.js
@@ -9,7 +9,7 @@ module.exports = api => {
   }, {
     isTs,
     usesRouter,
-    appName: packageJson.name,
+    appName: packageJson.name || 'appName',
   });
 
   api.extendPackage({

--- a/generator.js
+++ b/generator.js
@@ -1,7 +1,8 @@
 module.exports = api => {
   const isTs = api.entryFile.endsWith('.ts')
-  const packageJson = require(api.resolve('package.json'));
-  const usesRouter = Boolean(packageJson.dependencies && packageJson.dependencies['vue-router']);
+  const { dependencies, name } = require(api.resolve('package.json'));
+  const usesRouter = Boolean(dependencies && dependencies['vue-router']);
+  const appName = name || 'appName';
 
   api.render({
     [api.entryFile]: './template/src/main.js',
@@ -9,7 +10,7 @@ module.exports = api => {
   }, {
     isTs,
     usesRouter,
-    appName: packageJson.name || 'appName',
+    appName,
   });
 
   api.extendPackage({


### PR DESCRIPTION
I encountered this when trying to install vue-cli-plugin-single-spa through a preset.

<img width="1355" alt="Screen Shot 2020-06-03 at 4 08 14 PM" src="https://user-images.githubusercontent.com/4202993/83695068-9fb08c80-a5b6-11ea-8e29-d66a4d68646f.png">

This fix checks if dependencies is defined before checking the `vue-router` property on it. 

Side note: I actually think this is a timing issue, because a new project with defaults **does** have dependencies but they're not yet included. That issue leads me to [postProcessFiles](https://cli.vuejs.org/dev-guide/generator-api.html#postprocessfiles) so that these changes can be applied at the same time as `vue create`. Unfortunately, I haven't found a way to test local plugins while also using a preset.