### PR TITLE
Add preset

### DIFF
--- a/preset.json
+++ b/preset.json
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "vue-cli-plugin-single-spa": {
+      "version": "^1.1.1"
+    }
+  }
+}

--- a/template/src/set-public-path.js
+++ b/template/src/set-public-path.js
@@ -1,3 +1,3 @@
 import { setPublicPath } from 'systemjs-webpack-interop';
 
-setPublicPath('<%=appName%>');
+setPublicPath('<%=appName%>', 2);


### PR DESCRIPTION
Adding preset.json allows users to refer to this plugin within the vue-cli (eg. `vue create my-app --preset single-spa/vue-cli-plugin-single-spa`) and have it installed in a single step. Its also faster because it runs yarn/npm install only once.

The second change is something I noticed while working on the create-single-spa vue experience. Vue serves assets out of various folders, so changing the rootDirectoryLevel is needed in order to show it correctly. 