### PR TITLE
Set dependencies to empty object if not defined

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -2,7 +2,10 @@ const semver = require("semver");
 
 module.exports = (api) => {
   const isTs = api.entryFile.endsWith(".ts");
-  const { dependencies = {}, name } = require(api.resolve("package.json"));
+  const { dependencies, name } = require(api.resolve("package.json"));
+  if (!dependencies) {
+    throw Error(`Could not find any dependencies in package.json. Verify that you're in the correct directory, and that dependencies are defined.`);
+  }
   const usesRouter = Boolean(dependencies && dependencies["vue-router"]);
   const appName = name || "appName";
   const vueVersion = dependencies.vue;

--- a/generator.js
+++ b/generator.js
@@ -2,7 +2,7 @@ const semver = require("semver");
 
 module.exports = (api) => {
   const isTs = api.entryFile.endsWith(".ts");
-  const { dependencies, name } = require(api.resolve("package.json"));
+  const { dependencies = {}, name } = require(api.resolve("package.json"));
   const usesRouter = Boolean(dependencies && dependencies["vue-router"]);
   const appName = name || "appName";
   const vueVersion = dependencies.vue;

--- a/generator.js
+++ b/generator.js
@@ -2,9 +2,10 @@ const semver = require("semver");
 
 module.exports = (api) => {
   const isTs = api.entryFile.endsWith(".ts");
-  const { dependencies, name } = require(api.resolve("package.json"));
+  const packageJsonPath = api.resolve("package.json")
+  const { dependencies, name } = require(packageJsonPath);
   if (!dependencies) {
-    throw Error(`Could not find any dependencies in package.json. Verify that you're in the correct directory, and that dependencies are defined.`);
+    throw Error(`Could not find any dependencies declared in ${packageJsonPath}.`);
   }
   const usesRouter = Boolean(dependencies && dependencies["vue-router"]);
   const appName = name || "appName";


### PR DESCRIPTION
Related to #20, ~~this change defined a default value of dependencies. This should avoid errors when a project does not have a package.json or does not have any dependencies in package.json.~~ This change throws an error with clearer information if package.json is not found or no dependencies are declared in package.json.