### PR TITLE
Mark single-spa as a webpack external.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 const SystemJSPublicPathWebpackPlugin = require("systemjs-webpack-interop/SystemJSPublicPathWebpackPlugin");
 const StandaloneSingleSpaPlugin = require("standalone-single-spa-webpack-plugin");
-const { webpack } = require("webpack");
 
 module.exports = (api, options) => {
   options.css.extract = false;
@@ -45,5 +44,7 @@ module.exports = (api, options) => {
           disabled: process.env.STANDALONE_SINGLE_SPA !== "true",
         },
       ]);
+
+    webpackConfig.externals(["single-spa"]);
   });
 };


### PR DESCRIPTION
I realized we weren't doing this in [this slack thread](https://single-spa.slack.com/archives/CGGUQJMK6/p1607605403119000). Single-spa needs to be a singleton for its functions like getAppNames() to return the correct values.