### PR TITLE
Add jsonpFunction to webpack config.

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,8 @@ module.exports = (api, options) => {
         },
       ]);
 
+    webpackConfig.output.set("jsonpFunction", `webpackJsonp__${name}`);
+
     webpackConfig.externals(["single-spa"]);
   });
 };


### PR DESCRIPTION
See https://single-spa.slack.com/archives/CGGUQJMK6/p1614034876012000 and https://v4.webpack.js.org/configuration/output/#outputjsonpfunction. This avoids webpack modules from different MFEs accidentlaly mixing.