### PR TITLE
Add Vuex Store and Vuetify to Single-Spa setup

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -10,6 +10,8 @@ module.exports = (api) => {
     );
   }
   const usesRouter = Boolean(dependencies && dependencies["vue-router"]);
+  const useStore = Boolean(dependencies && dependencies["vuex"]);
+  const useVuetify = Boolean(dependencies && dependencies["vuetify"]);
   const appName = name || "appName";
   const vueVersion = dependencies.vue;
   if (!vueVersion) {
@@ -26,6 +28,8 @@ module.exports = (api) => {
     {
       isTs,
       usesRouter,
+      useStore,
+      useVuetify,
       appName,
     }
   );

--- a/template/src/main-vue-2.js
+++ b/template/src/main-vue-2.js
@@ -2,7 +2,9 @@ import Vue from 'vue';
 import singleSpaVue from 'single-spa-vue';
 
 import App from './App.vue';<% if (usesRouter) { %>
-import router from './router';<% } %>
+import router from './router';<% } %><% if (useStore) { %>
+import store from './store';<% } %><% if (useVuetify) { %>
+import vuetify from './plugins/vuetify'<% } %>
 
 Vue.config.productionTip = false;
 
@@ -23,7 +25,9 @@ const vueLifecycles = singleSpaVue({
         },
       });
     },<% if (usesRouter) { %>
-    router,<% } %>
+    router,<% } %><% if (usesStore) { %>
+    store,<% } %><% if (usesVuetify) { %>
+    vuetify,<% } %>
   },
 });
 

--- a/template/src/main-vue-3.js
+++ b/template/src/main-vue-3.js
@@ -2,7 +2,9 @@ import { h, createApp } from 'vue';
 import singleSpaVue from 'single-spa-vue';
 
 import App from './App.vue';<% if (usesRouter) { %>
-import router from './router';<% } %>
+import router from './router';<% } %><% if (useStore) { %>
+import store from './store';<% } %><% if (useVuetify) { %>
+import vuetify from './plugins/vuetify'<% } %>
 
 const vueLifecycles = singleSpaVue({
   createApp,
@@ -19,9 +21,11 @@ const vueLifecycles = singleSpaVue({
         */
       });
     },
-  },<% if (usesRouter) { %>
-  handleInstance(app) {
-    app.use(router);
+  },<% if (usesRouter || useStore || useVuetify) { %>
+  handleInstance(app) {<% if (usesRouter) { %>
+    app.use(router);<% } %>% if (usesStore) { %>
+    app.use(store);<% } %><% if (usesVuetify) { %>
+    app.use(vuetify);<% } %>
   },<% } %>
 });
 


### PR DESCRIPTION
This PR adds check for the vuex and vuetify dependencies and template if conditionals for adding them to the template. 

Vuex is a heavily used module in vue apps so it would only make sense to add this to the template when a user selects it in their vue app.

Vuetify has made it's mark on the vue community as a fully supported design system both for its ease of use in vue apps and its customizable options. They are invited to all the vue conferences to present and are continuously praised by the vue core team. 

These are the reasons I think these two should be involved with your plugin 