### PR TITLE
Fix a few variable names for store Vuex and Vuetify support

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -10,8 +10,8 @@ module.exports = (api) => {
     );
   }
   const usesRouter = Boolean(dependencies && dependencies["vue-router"]);
-  const useStore = Boolean(dependencies && dependencies["vuex"]);
-  const useVuetify = Boolean(dependencies && dependencies["vuetify"]);
+  const usesStore = Boolean(dependencies && dependencies["vuex"]);
+  const usesVuetify = Boolean(dependencies && dependencies["vuetify"]);
   const appName = name || "appName";
   const vueVersion = dependencies.vue;
   if (!vueVersion) {
@@ -28,8 +28,8 @@ module.exports = (api) => {
     {
       isTs,
       usesRouter,
-      useStore,
-      useVuetify,
+      usesStore,
+      usesVuetify,
       appName,
     }
   );

--- a/template/src/main-vue-2.js
+++ b/template/src/main-vue-2.js
@@ -2,8 +2,8 @@ import Vue from 'vue';
 import singleSpaVue from 'single-spa-vue';
 
 import App from './App.vue';<% if (usesRouter) { %>
-import router from './router';<% } %><% if (useStore) { %>
-import store from './store';<% } %><% if (useVuetify) { %>
+import router from './router';<% } %><% if (usesStore) { %>
+import store from './store';<% } %><% if (usesVuetify) { %>
 import vuetify from './plugins/vuetify'<% } %>
 
 Vue.config.productionTip = false;

--- a/template/src/main-vue-3.js
+++ b/template/src/main-vue-3.js
@@ -2,8 +2,8 @@ import { h, createApp } from 'vue';
 import singleSpaVue from 'single-spa-vue';
 
 import App from './App.vue';<% if (usesRouter) { %>
-import router from './router';<% } %><% if (useStore) { %>
-import store from './store';<% } %><% if (useVuetify) { %>
+import router from './router';<% } %><% if (usesStore) { %>
+import store from './store';<% } %><% if (usesVuetify) { %>
 import vuetify from './plugins/vuetify'<% } %>
 
 const vueLifecycles = singleSpaVue({
@@ -21,7 +21,7 @@ const vueLifecycles = singleSpaVue({
         */
       });
     },
-  },<% if (usesRouter || useStore || useVuetify) { %>
+  },<% if (usesRouter || usesVuetify || usesVuetify) { %>
   handleInstance(app) {<% if (usesRouter) { %>
     app.use(router);<% } %>% if (usesStore) { %>
     app.use(store);<% } %><% if (usesVuetify) { %>

--- a/template/src/main-vue-3.js
+++ b/template/src/main-vue-3.js
@@ -21,7 +21,7 @@ const vueLifecycles = singleSpaVue({
         */
       });
     },
-  },<% if (usesRouter || usesVuetify || usesVuetify) { %>
+  },<% if (usesRouter || usesStore || usesVuetify) { %>
   handleInstance(app) {<% if (usesRouter) { %>
     app.use(router);<% } %>% if (usesStore) { %>
     app.use(store);<% } %><% if (usesVuetify) { %>


### PR DESCRIPTION
A recent commit added support for Vuex and Vuetify, but had some incorrect variable names that broke the generator.

To keep consistent with the prior variable naming convention, I updated `useStore` to `usesStore` and `useVuetify` to `usesVuetify`, similar to `usesRouter`.