### PR TITLE
Automate Tests suggested by Contribution Guidelines

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -5,7 +5,7 @@ on:
   - pull_request
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -19,3 +19,31 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run check-format
       - run: pnpm run lint
+
+  test:vue2:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "15"
+      - uses: pnpm/action-setup@v1.2.1
+        with:
+          version: 5.14.1
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run test:vue2
+
+  test:vue3:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "15"
+      - uses: pnpm/action-setup@v1.2.1
+        with:
+          version: 5.14.1
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run test:vue3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: pnpm/action-setup@v1.2.1
         with:
           version: 5.14.1
+      - run: pnpm add -g @vue/cli
       - run: pnpm install --frozen-lockfile
       - run: pnpm run test:vue2
 
@@ -45,5 +46,6 @@ jobs:
       - uses: pnpm/action-setup@v1.2.1
         with:
           version: 5.14.1
+      - run: pnpm add -g @vue/cli
       - run: pnpm install --frozen-lockfile
       - run: pnpm run test:vue3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,7 +20,7 @@ jobs:
       - run: pnpm run check-format
       - run: pnpm run lint
 
-  test:vue2:
+  test_vue2:
     runs-on: ubuntu-latest
 
     steps:
@@ -34,7 +34,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run test:vue2
 
-  test:vue3:
+  test_vue3:
     runs-on: ubuntu-latest
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ typings/
 
 # next.js build output
 .next
+
+# Test Directories
+tests/test-app-vue2
+tests/test-app-vue3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,24 @@ See [this guide](https://cli.vuejs.org/dev-guide/plugin-dev.html#installing-plug
 
 _Make sure to test both Vue 2 and Vue 3, with separate test-apps!_
 
+Manually:
+
 ```
 vue create test-app
 cd test-app
 yarn add --dev file:../vue-cli-plugin-single-spa
 vue invoke single-spa
+```
+
+Automatically:
+
+```
+pnpm run test
+```
+
+You can also run the tests separately for Vue2 and Vue3
+
+```
+pnpm run test:vue2
+pnpm run test:vue3
 ```

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "format": "prettier --write .",
     "check-format": "prettier --check .",
     "lint": "eslint . && ejslint ./template/src",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "test": "tests/test.sh",
+    "test:vue2": "tests/testVue.sh 2",
+    "test:vue3": "tests/testVue.sh 3"
   },
   "author": "Joel Denning",
   "license": "MIT",

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if basename "$PWD" != "tests"; then
+  cd tests
+fi
+
+bash testVue.sh 2
+bash testVue.sh 3

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-if basename "$PWD" != "tests"; then
+i= basename "$PWD"
+
+if [ "$i" != "tests" ]; then
   cd tests
 fi
 
-bash testVue.sh 2
-bash testVue.sh 3
+bash testVue.sh 2 && bash testVue.sh 3 || exit 1

--- a/tests/testVue.sh
+++ b/tests/testVue.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ $1 == 2 ] || [ $1 == 3 ];
+then
+  ProjectName="test-app-vue$1"
+
+  if basename "$PWD" != "tests"; then
+    cd tests
+  fi
+
+  cleanup() (
+    cd ..
+    rm -rf $ProjectName
+  )
+
+  echo $ProjectName
+
+  vue create $ProjectName --no-git --inlinePreset '{"useConfigFiles": true,"plugins": {},"vueVersion": "2"}' || exit 1
+
+  cd $ProjectName
+  yarn add --dev file:../.. || (cleanup && exit 1)
+  yes Y | vue invoke single-spa || (cleanup && exit 1)
+  yarn run build || (cleanup && exit 1)
+
+  cleanup
+else
+  echo "$1 is no valid Vue Version"
+  exit 1  
+fi
+

--- a/tests/testVue.sh
+++ b/tests/testVue.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
+i= basename "$PWD"
+
 if [ $1 == 2 ] || [ $1 == 3 ];
 then
   ProjectName="test-app-vue$1"
 
-  if basename "$PWD" != "tests"; then
+  if [ "$i" != "tests" ]; then
     cd tests
   fi
 
@@ -15,14 +17,15 @@ then
 
   echo $ProjectName
 
-  vue create $ProjectName --no-git --inlinePreset '{"useConfigFiles": true,"plugins": {},"vueVersion": "2"}' || exit 1
+  vue create $ProjectName --no-git --inlinePreset "{\"useConfigFiles\": true,\"plugins\": {},\"vueVersion\": \"$1\"}" || ERRCODE=$?
 
   cd $ProjectName
-  yarn add --dev file:../.. || (cleanup && exit 1)
-  yes Y | vue invoke single-spa || (cleanup && exit 1)
-  yarn run build || (cleanup && exit 1)
+  yarn add --dev file:../.. || ERRCODE=$?
+  yes Y | vue invoke single-spa || ERRCODE=$?
+  yarn run build || ERRCODE=$?
 
   cleanup
+  exit $ERRCODE
 else
   echo "$1 is no valid Vue Version"
   exit 1  


### PR DESCRIPTION
Hi,
as announced I worked on creating some tests for the package.
At first I thought about using Jest. But since the basic stuff that is helpful to test is the full invokation functionality. I opted to just automate the Tests, which are suggested by the existing Contributing Guidelines with Bashscripts.

That's what this PR is. It introduces a script that can create Vue2 and/or Vue3 TestApps, installs the Plugin, invokes it and starts one build before cleaning up behind itself. I also added the tests to the GitHub Actions in separate Jobs for Vue2 and Vue3.

I did not add @vue/cli as a dependency for the project even tho the bash scripts do need a global installation of it.

I hope it's fine like that I'm not the best Bash developer.
I tested the scripts with different errors in the Plugin for both Vue2 and Vue3.